### PR TITLE
1- Add new --ssl parameter. Forces the use of t3s on demand instead o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ Tested on Oracle Weblogic 11 and OpenJDK 8 (for client).
 + Gets a **remote sql shell** via a JDBC datasource;
 + With a privileged account, you can **deploy an application** on the weblogic server in order to have a Web shell for example.
 
+ 
+# Requirements
+
++ OpenJDK 8
+
 
 # Usage examples
 
@@ -129,6 +134,14 @@ To undeploy a specific application named *appli-name-displayed*:
 ```bash
 java -jar Jndiat.jar deployer -s 192.168.56.101 -p 7002 -U weblogic -P welcome1 --undeploy --display-name 'appli-name-displayed'
 ```
+
+## Force SSL version of t3 protocol
+In some corner cases, the autodetection of t3s usage is not working properly. It is possible to force the use of t3s instead to t3 with the use of *--ssl*.
+
+```bash
+java -jar Jndiat.jar [module] --ssl [...]
+```
+
 
 Special thanks
 ====

--- a/source/BruteForce.java
+++ b/source/BruteForce.java
@@ -19,14 +19,16 @@ public class BruteForce extends T3Connection{
 	private String credFilename;
 	private String ip;
 	private Integer port;
+	private boolean isSSL;
 	private String separator;
 			
 	//*************   Constructor *************
-	public BruteForce(String ip, Integer port, String initial_context_factory, boolean printErrorConnection, String credFilename, String separator){
+	public BruteForce(String ip, Integer port, boolean isSSL, String initial_context_factory, boolean printErrorConnection, String credFilename, String separator){
 		super(initial_context_factory, false);
 		myLogger.fine("Brutforce object created");
 		this.ip = ip;
 		this.port = port;
+		this.isSSL = isSSL;
 		this.accountsFound = new ArrayList<String[]>();
 		this.credFilename = credFilename;
 		this.separator = separator;
@@ -62,7 +64,7 @@ public class BruteForce extends T3Connection{
 				creds = line.replaceAll("\n","").replaceAll("\t","").replaceAll("\r","").split(this.separator);
 				if (creds.length == 0) {creds = new String[]{"",""};};
 				myLogger.finer("Using the username '"+creds[0]+"' and the password '"+creds[1]+"'");
-				connectionStatus = connection (this.ip, this.port, creds[0], creds[1]);
+				connectionStatus = connection (this.ip, this.port, this.isSSL, creds[0], creds[1]);
 				if (connectionStatus == true){
 					myLogger.fine("We can use the login '"+creds[0]+"' with the password '"+creds[1]+"' to establish a T3 connection");
 					this.accountsFound.add(creds);

--- a/source/Deployer.java
+++ b/source/Deployer.java
@@ -22,6 +22,7 @@ public class Deployer extends MyPrinter{
 	private static ModuleType[] moduleTypeTable = new ModuleType[] {ModuleType.EAR,ModuleType.WAR,ModuleType.EJB,ModuleType.RAR,ModuleType.CAR};
 	private String ip;
 	private String port;
+	private boolean isSSL;
 	private String username;
 	private String password;
 	private WebLogicDeploymentManager deployManager;
@@ -29,10 +30,11 @@ public class Deployer extends MyPrinter{
 	private T3s t3s;
 
 	/*Constructor*/
-	public Deployer(String ip, int port, String username, String password, String target){
+	public Deployer(String ip, int port, String username, boolean isSSL, String password, String target){
 		myLogger.fine("Deployer object created");
 		this.ip=ip;
 		this.port=Integer.toString(port);
+		this.isSSL=isSSL;
 		this.username=username;
 		this.password=password;
 		this.deployManager=null;
@@ -148,7 +150,7 @@ public class Deployer extends MyPrinter{
 			myLogger.info("Connection to "+this.ip+":"+this.port+"established throuth T3 protocol, good news:)");
 			return deployManager;
 		}catch (Exception e) {
-			if (this.getStackTrace(e).contains(this.ERROR_CONNECTION_RESET)){
+			if (this.getStackTrace(e).contains(this.ERROR_CONNECTION_RESET) || this.isSSL==true){
 				myLogger.fine("Trying to connect with t3s (t3 over SSL) because there is a reset with t3");
 				this.t3s = new T3s (this.ip, Integer.parseInt(this.port));
 				if (t3s.makeT3sConfig() == false){

--- a/source/JndiListing.java
+++ b/source/JndiListing.java
@@ -13,8 +13,8 @@ public class JndiListing extends T3Connection{
 	
 	final String JDBC_CLASS_DATASOURCE_ID = ".jdbc.";
 
-	public JndiListing(String ip, Integer port, String username, String password){
-		super(ip, port, username, password, "weblogic.jndi.WLInitialContextFactory", true);
+	public JndiListing(String ip, Integer port, boolean isSSL, String username, String password){
+		super(ip, port, isSSL, username, password, "weblogic.jndi.WLInitialContextFactory", true);
 		myLogger.fine("JndiListing object created");
 		this.paths = new ArrayList<String[]>();
 		this.lastPath = new ArrayList();

--- a/source/Jndiat.java
+++ b/source/Jndiat.java
@@ -78,6 +78,7 @@ public class Jndiat extends MyPrinter {
 		addUsefulOptions(parserScan);
 		ArgumentGroup commonGroupParserScan = parserScan.addArgumentGroup("common options");
 		addServerOption (commonGroupParserScan);
+		addSSLOption (commonGroupParserScan);
 		addCredentialsOptions (commonGroupParserScan);
 		ArgumentGroup mandatoryGroupParserScan = parserScan.addArgumentGroup("a mandatory command");
 		mandatoryGroupParserScan.addArgument("--ports").dest("ports").setDefault("").help("port(s) to scan");
@@ -86,6 +87,7 @@ public class Jndiat extends MyPrinter {
 		addUsefulOptions(parserBruteForce);
 		ArgumentGroup commonGroupParserBruteForce = parserBruteForce.addArgumentGroup("common options");
 		addServerOption (commonGroupParserBruteForce);
+		addSSLOption (commonGroupParserBruteForce);
 		addPortArgument (commonGroupParserBruteForce);
 		ArgumentGroup specificGroupParserBruteForce = parserBruteForce.addArgumentGroup("specific options");
 		specificGroupParserBruteForce.addArgument("--cred-file").dest("cred-file").setDefault("").help("credentials file to use");
@@ -179,7 +181,7 @@ public class Jndiat extends MyPrinter {
 			myLogger.info("You want to scan the "+ns.getString("server")+" target on port(s) "+ns.getString("ports")+", starting...");
 			Scanner scanner = new Scanner();
 			this.disableColorInObjectIfNeeded(scanner);
-			scanner.scan(ns.getString("server"),ns.getString("ports"),ns.getString("username"),ns.getString("password"));
+			scanner.scan(ns.getString("server"),ns.getString("ports"),ns.getBoolean("ssl"),ns.getString("username"),ns.getString("password"));
 			scanner.printOpenedPorts();
 			}
 			else {
@@ -190,7 +192,7 @@ public class Jndiat extends MyPrinter {
 		if (ns.getString("module")=="bruteforce") {
 			this.printTitle("Searching valid credentials");
 			myLogger.info("You want to search valid credentials to "+ns.getString("server")+" target on port "+ns.getString("port")+", starting...");
-			BruteForce bruteForce = new BruteForce(ns.getString("server"),ns.getInt("port"),"weblogic.jndi.WLInitialContextFactory", false, ns.getString("cred-file"), ns.getString("separator"));
+			BruteForce bruteForce = new BruteForce(ns.getString("server"),ns.getInt("port"),ns.getBoolean("ssl"),"weblogic.jndi.WLInitialContextFactory", false, ns.getString("cred-file"), ns.getString("separator"));
 			this.disableColorInObjectIfNeeded(bruteForce);
 			bruteForce.searchValidCreds();
 			bruteForce.printValidCreds();
@@ -199,14 +201,14 @@ public class Jndiat extends MyPrinter {
 		if (ns.getString("module")=="list"){
 			this.printTitle("Listing JNDI accessible with the T3 protocol");
 			myLogger.info("You want to list JNDI on the "+ns.getString("server")+" target on port "+ns.getInt("port")+", starting...");
-			JndiListing jndiListing = new JndiListing(ns.getString("server"),ns.getInt("port"),ns.getString("username"),ns.getString("password"));
+			JndiListing jndiListing = new JndiListing(ns.getString("server"),ns.getInt("port"),ns.getBoolean("ssl"),ns.getString("username"),ns.getString("password"));
 			jndiListing.printJndi();
 		}
 		//datasource module
 		if (ns.getString("module")=="datasource"){
 			String datasourceToUse = "";
 			myLogger.info("You want to get SQL connection from a datasource on the "+ns.getString("server")+" target on port "+ns.getInt("port")+", starting...");
-			SQLDataSource sqlDataSource = new SQLDataSource(ns.getString("server"),ns.getInt("port"),ns.getString("username"),ns.getString("password"));
+			SQLDataSource sqlDataSource = new SQLDataSource(ns.getString("server"),ns.getInt("port"),ns.getBoolean("ssl"),ns.getString("username"),ns.getString("password"));
 			//sqlshell
 			if (ns.getBoolean("sqlshell")==true){
 				this.printTitle("You want a SQL shell");
@@ -248,13 +250,13 @@ public class Jndiat extends MyPrinter {
 		if (ns.getString("module")=="mejb"){
 			this.printTitle("Accessing the MEJB through T3 protocol");
 			myLogger.info("You want to access the MEJB on the "+ns.getString("server")+" target on port "+ns.getInt("port")+", starting...");
-			Mejb mejb = new Mejb(ns.getString("server"),ns.getInt("port"),ns.getString("username"),ns.getString("password"));
+			Mejb mejb = new Mejb(ns.getString("server"),ns.getInt("port"),ns.getBoolean("ssl"),ns.getString("username"),ns.getString("password"));
 			mejb.getAllJMONames();
 		}
 		
 		//deploy module
 		if (ns.getString("module")=="deployer"){
-			Deployer deployer = new Deployer(ns.getString("server"),ns.getInt("port"),ns.getString("username"),ns.getString("password"),ns.getString("target"));
+			Deployer deployer = new Deployer(ns.getString("server"),ns.getInt("port"),ns.getBoolean("ssl"),ns.getString("username"),ns.getString("password"),ns.getString("target"));
 			if (ns.getBoolean("deploy")==true){
 				this.printTitle("Deploy the application "+ns.getString("app-file"));
 				if (new File(ns.getString("app-file")).exists()==false){
@@ -301,6 +303,10 @@ public class Jndiat extends MyPrinter {
 		commonGroup.addArgument("-s").dest("server").help("target");
 	}
 	
+	private void addSSLOption (ArgumentGroup commonGroup){
+		commonGroup.addArgument("--ssl").dest("ssl").action(Arguments.storeTrue()).help("uses ssl (t3s)");
+	}
+	
 	public void addCredentialsOptions (ArgumentGroup commonGroup){
 		commonGroup.addArgument("-U").dest("username").setDefault("").help("username");
 		commonGroup.addArgument("-P").dest("password").setDefault("").help("password");
@@ -309,6 +315,7 @@ public class Jndiat extends MyPrinter {
 	private void addCommonOptions(Subparser parser){
 		ArgumentGroup commonGroup = parser.addArgumentGroup("common options");
 		addServerOption (commonGroup);
+		addSSLOption (commonGroup);
 		addCredentialsOptions (commonGroup);
 		addPortArgument(commonGroup);
 	}

--- a/source/Mejb.java
+++ b/source/Mejb.java
@@ -27,8 +27,8 @@ public class Mejb extends T3Connection{
 	private ManagementHome home;
 	
 	//*************   Constructor *************
-	public Mejb(String ip, Integer port, String username, String password){
-		super(ip, port, username, password, "weblogic.jndi.WLInitialContextFactory", true);
+	public Mejb(String ip, Integer port, boolean isSSL, String username, String password){
+		super(ip, port, isSSL, username, password, "weblogic.jndi.WLInitialContextFactory", true);
 		myLogger.fine("SQLDataSource object created");
 		this.home = null;
 	}

--- a/source/SQLDataSource.java
+++ b/source/SQLDataSource.java
@@ -36,8 +36,8 @@ public class SQLDataSource extends T3Connection {
 	private Connection connection;
 	private String dataSource;
 	
-	public SQLDataSource(String ip, Integer port, String username, String password){
-		super(ip, port, username, password, "weblogic.jndi.WLInitialContextFactory", true);
+	public SQLDataSource(String ip, Integer port, boolean isSSL, String username, String password){
+		super(ip, port, isSSL, username, password, "weblogic.jndi.WLInitialContextFactory", true);
 		myLogger.fine("SQLDataSource object created");
 		this.connection = null;
 		this.dataSource = "";

--- a/source/Scanner.java
+++ b/source/Scanner.java
@@ -21,7 +21,7 @@ public class Scanner extends T3Connection{
 	
 	/* To scan ports of a server
 	 * Compute openedPorts */
-	public void scan (String ip, String ports, String username, String password){
+	public void scan (String ip, String ports, boolean isSSL, String username, String password){
 		myLogger.info("Scanning ports '"+ports+"' of "+ip+" with password '"+username+"' and password '"+password+"'");
 		int nb;
 		boolean connected = false;
@@ -49,7 +49,7 @@ public class Scanner extends T3Connection{
 		for (nb=0; nb<portsList.length; nb++) {
 			myLogger.fine("Scanning the port "+portsList[nb]);
 			int portToTest = Integer.valueOf(portsList[nb]);
-			connected = this.connection(ip, portToTest, username, password);
+			connected = this.connection(ip, portToTest, isSSL, username, password);
 			if (connected == true){
 				myLogger.fine("Target "+ip+":"+portToTest+" : T3 connection establish :)");
 				this.openedPorts.add(portToTest);

--- a/source/T3Connection.java
+++ b/source/T3Connection.java
@@ -13,6 +13,7 @@ public class T3Connection extends MyPrinter {
 	private static Logger myLogger = Logger.getLogger("JNDIAT");
 	private String ip;
 	private int port;
+	private boolean isSSL;
 	private String user;
 	private String password;
 	private String uri;
@@ -32,7 +33,7 @@ public class T3Connection extends MyPrinter {
 		this.t3s = null;
 	}
 	
-	public T3Connection(String ip, int port, String username, String password, String initial_context_factory, boolean cntionErrorAsSevereError){
+	public T3Connection(String ip, int port, boolean isSSL, String username, String password, String initial_context_factory, boolean cntionErrorAsSevereError){
 		super();
 		myLogger.fine("T3Connection object created");
 		this.initial_context_factory = initial_context_factory;
@@ -40,6 +41,7 @@ public class T3Connection extends MyPrinter {
 		this.cntionErrorAsSevereError = cntionErrorAsSevereError;
 		this.ip = ip;
 		this.port = port;
+		this.isSSL = isSSL;
 		this.user = username;
 		this.password = password;
 		this.t3s = null;
@@ -47,10 +49,11 @@ public class T3Connection extends MyPrinter {
 	
 	//*************   Connection *************
 	//Return True if connected. Otherwise return False
-	public boolean connection (String ip, int port, String username, String password){
-		myLogger.fine("Try to establish a connection to "+ip+":"+port+" with credentials '"+username+"'/'"+password+"'");
+	public boolean connection (String ip, int port, boolean isSSL, String username, String password){
+		myLogger.fine("Try to establish a connection to "+ip+":"+port+" with credentials '"+username+"'/'"+password+"' and ssl="+isSSL.toString()+"");
 		this.ip = ip;
 		this.port = port;
+		this.isSSL = isSSL;
 		this.user = username;
 		this.password = password;
 		this.uri = "t3://"+ this.ip +":"+ this.port +"";
@@ -65,7 +68,7 @@ public class T3Connection extends MyPrinter {
 			myLogger.fine("You can use "+ip+":"+port+" with credentials '"+username+"'/'"+password+"'");
 			return true;
 		}catch (CommunicationException er) {
-			if (er.toString().contains(ERROR_CONNECTION_RESET)){
+			if (er.toString().contains(ERROR_CONNECTION_RESET) || this.isSSL==true){
 				myLogger.fine("Trying to connect with t3s (t3 over SSL) because there is a reset with t3");
 				this.t3s = new T3s (this.ip, this.port);
 				if (t3s.makeT3sConfig() == false){


### PR DESCRIPTION
Hello,

I have an Oracle WebLogic (12.2.1.4.0) server with a known working t3s service. The issue is that for any t3 connection (or in fact socket), the server return the following string `^U^C^C^@^B^BP` instead of what seems to be expected from `jndiat` source code (`java.net.SocketException: Connection reset`). With such string here is the raised exception: `javax.naming.CommunicationException [Root exception is weblogic.socket.UnrecoverableConnectException: [Login failed for an unknown reason: P]]`

As the initial autodetect method for t3s seems to not be a universal solution and the actual possibilities does not seem clear and/or definable, I propose a manual backup solution to force the use of t3s protocol when the service is known to use it.

To do that, I implemented a new `--ssl` parameter. Associated documentation is provided.

As a complementary improvment, I added a `Requirements` section in the documentation to specify any runtime requirement.

FYI, due to complexity and unknowns in the build process of `jndiat`, I propose an implementation of this change but I was not able to compile and test what is proposed.


As a side note, to help future commit made on this repo but also reproduction of the work, would it be possible to share the compilation details used on your side?


Thank you to consider my request.

Best regards,